### PR TITLE
Password generator fix and some gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packer/
 .idea/
 
 */_build
+doc/~$erGuide_EUMW.docx

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ packer/
 *Jenkinsfile
 .hg/
 
+# IntelliJ project files
+*.iml
+*.iws
+*.ipr
+.idea/
+
+*/_build

--- a/password-generator/pom.xml
+++ b/password-generator/pom.xml
@@ -35,6 +35,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/password-generator/src/main/java/de/eumw/password_generator/BCryptPasswordGenerator.java
+++ b/password-generator/src/main/java/de/eumw/password_generator/BCryptPasswordGenerator.java
@@ -10,6 +10,7 @@
 
 package de.eumw.password_generator;
 
+import org.apache.log4j.BasicConfigurator;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class BCryptPasswordGenerator
 //Generate password
   public static void main(String[] args)
   {
+    BasicConfigurator.configure();
     if (args.length != 1 || containsHelp(args[0]))
     {
       printUsage();


### PR DESCRIPTION
We could not use the password generator due to lacking dependency as well as lacking initiation of log framework. After the amendments in this pull request, we could use the passord generator as intended.