### PR TITLE
Eidas signer update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ packer/
 .idea/
 
 */_build
+doc/~$erGuide_EUMW.docx

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,10 @@ packer/
 *Jenkinsfile
 .hg/
 
+# IntelliJ project files
+*.iml
+*.iws
+*.ipr
+.idea/
+
+*/_build

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
@@ -23,6 +23,11 @@ public class EidasSigner
 {
 
   /**
+   * The default hash algoritm. This value can be overridden by environment variable.
+   */
+  private static String defaultHashAlgo="SHA256-PSS";
+
+  /**
    * signature key
    */
   private final PrivateKey sigKey;
@@ -42,6 +47,11 @@ public class EidasSigner
    */
   private final SigEntryType sigType;
 
+  static {
+    String envHashSetting = System.getenv("EIDAS_SIGNER_HASH_ALGORITHM");
+    defaultHashAlgo = envHashSetting != null ? envHashSetting : defaultHashAlgo;
+  }
+
   private EidasSigner(boolean includeCert, PrivateKey key, X509Certificate cert, String digestAlg)
   {
     if (key == null || cert == null || digestAlg == null)
@@ -60,14 +70,14 @@ public class EidasSigner
    * using a cert if a RSA Key or http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256 if using a cert with a
    * EC key. The canonicalization algorithm is set to http://www.w3.org/2001/10/xml-exc-c14n# and the digest
    * algorithm to http://www.w3.org/2001/04/xmlenc#sha256
-   * 
+   *
    * @param includeCert
    * @param key
    * @param cert
    */
   public EidasSigner(boolean includeCert, PrivateKey key, X509Certificate cert)
   {
-    this(includeCert, key, cert, "SHA256-PSS");
+    this(includeCert, key, cert, defaultHashAlgo);
   }
 
   EidasSigner(PrivateKey key, X509Certificate cert)

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
@@ -48,7 +48,7 @@ public class EidasSigner
   private final SigEntryType sigType;
 
   static {
-    String envHashSetting = System.getenv("EIDAS_SIGNER_HASH_ALGORITHM");
+    String envHashSetting = System.getenv("EIDAS_SIGNER_DEFAULT_HASH_ALGORITHM");
     defaultHashAlgo = envHashSetting != null ? envHashSetting : defaultHashAlgo;
   }
 

--- a/password-generator/pom.xml
+++ b/password-generator/pom.xml
@@ -35,10 +35,6 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
-        </dependency>
     </dependencies>
 
     <build>

--- a/password-generator/pom.xml
+++ b/password-generator/pom.xml
@@ -35,6 +35,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-log4j12</artifactId>
+        </dependency>
     </dependencies>
 
     <build>

--- a/password-generator/src/main/java/de/eumw/password_generator/BCryptPasswordGenerator.java
+++ b/password-generator/src/main/java/de/eumw/password_generator/BCryptPasswordGenerator.java
@@ -10,6 +10,7 @@
 
 package de.eumw.password_generator;
 
+import org.apache.log4j.BasicConfigurator;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 import lombok.extern.slf4j.Slf4j;
@@ -28,6 +29,7 @@ public class BCryptPasswordGenerator
 //Generate password
   public static void main(String[] args)
   {
+    BasicConfigurator.configure();
     if (args.length != 1 || containsHelp(args[0]))
     {
       printUsage();

--- a/password-generator/src/main/java/de/eumw/password_generator/BCryptPasswordGenerator.java
+++ b/password-generator/src/main/java/de/eumw/password_generator/BCryptPasswordGenerator.java
@@ -10,7 +10,6 @@
 
 package de.eumw.password_generator;
 
-import org.apache.log4j.BasicConfigurator;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +28,6 @@ public class BCryptPasswordGenerator
 //Generate password
   public static void main(String[] args)
   {
-    BasicConfigurator.configure();
     if (args.length != 1 || containsHelp(args[0]))
     {
       printUsage();


### PR DESCRIPTION
This PR provides an update to the EidasSigner class that allows the default hash algoritm to be set by the ENV variable EIDAS_SIGNER_DEFAULT_HASH_ALGORITHM

This means that it is possible to set another default value than the current hardwired "SHA256-PSS" default value. The  "SHA256-PSS" value is kept intact if no ENV variable value is set.
