### PR TITLE
Improvements and bug fixes

### DIFF
--- a/Dockerfile-eidas-middleware-build
+++ b/Dockerfile-eidas-middleware-build
@@ -1,0 +1,23 @@
+FROM governikus/eidas-base-container:1.0.4-rc.2
+MAINTAINER Benny Prange <benny.prange@governikus.de>
+
+# Define the location of the configuration directory inside of the container
+ENV SPRING_CONFIG_ADDITIONAL_LOCATION=file:${CONFIG_DIR}/
+
+# Expose the ports we're interested in
+EXPOSE 8443
+
+# Fix the folder permissions because mounting with -v will mount with root
+RUN mkdir -p /opt/eidas-middleware/database &&\
+    chown eidas-middleware /opt/eidas-middleware/database &&\
+    chgrp eidas-middleware /opt/eidas-middleware/database
+
+# Change to the eidas user and directory
+USER eidas-middleware
+WORKDIR /opt/eidas-middleware
+
+# Add built eidas middleware application
+ADD eidas-middleware/target/eidas-middleware.jar eidas-middleware.jar
+RUN mkdir -p ${CONFIG_DIR}
+
+ENTRYPOINT ["java", "-jar", "./eidas-middleware.jar"]

--- a/Dockerfile-eidas-middleware-build
+++ b/Dockerfile-eidas-middleware-build
@@ -7,6 +7,7 @@ ENV SPRING_CONFIG_ADDITIONAL_LOCATION=file:${CONFIG_DIR}/
 # Expose the ports we're interested in
 EXPOSE 8443
 
+
 # Fix the folder permissions because mounting with -v will mount with root
 RUN mkdir -p /opt/eidas-middleware/database &&\
     chown eidas-middleware /opt/eidas-middleware/database &&\
@@ -20,4 +21,5 @@ WORKDIR /opt/eidas-middleware
 ADD eidas-middleware/target/eidas-middleware.jar eidas-middleware.jar
 RUN mkdir -p ${CONFIG_DIR}
 
-ENTRYPOINT ["java", "-jar", "./eidas-middleware.jar"]
+#ENTRYPOINT ["java", "-jar", "./eidas-middleware.jar"]
+ENTRYPOINT ["java","-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=8218","-jar","eidas-middleware.jar"]

--- a/eidas-common/src/main/java/de/governikus/eumw/eidascommon/Utils.java
+++ b/eidas-common/src/main/java/de/governikus/eumw/eidascommon/Utils.java
@@ -580,6 +580,15 @@ public final class Utils
     return createOwnUrlPrefix(req) + req.getContextPath();
   }
 
+  public static String getMiddlewareServiceEntityId(HttpServletRequest req){
+    String envEntityId=getMiddlewareServiceEntityId();
+    return envEntityId != null ? envEntityId : createOwnURLWithContextPath(req) + "/Metadata";
+  }
+
+  public static String getMiddlewareServiceEntityId(){
+    return System.getenv("SERVICE_IDP_ENTITY_ID");
+  }
+
   /**
    * Returns an HTML page for an error case.
    */

--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/Metadata.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/Metadata.java
@@ -80,7 +80,7 @@ public class Metadata extends HttpServlet
     try
     {
       byte[] out = EidasSaml.createMetaDataService("_eumiddleware",
-                                                   request.getRequestURL().toString(),
+                                                   Utils.getMiddlewareServiceEntityId(request),
                                                    Constants.parse("2020-12-31T0:00:00.000Z"),
                                                    ConfigHolder.getSignatureCert(),
                                                    ConfigHolder.getDecryptionCert(),

--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
@@ -547,8 +547,7 @@ public class ResponseSender extends HttpServlet
     log.warn(requestInfo(reqSP, reqRelayState));
     log.warn(error.toDescription(msg));
     response.setStatus(400);
-    String serverurl = Utils.createOwnURLWithContextPath(req)
-            + "/Metadata";
+    String serverurl = Utils.getMiddlewareServiceEntityId(req);
     EidasSigner signer;
     try
     {

--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
@@ -421,8 +421,7 @@ public class ResponseSender extends HttpServlet
     UnmarshallingException, EncryptionException, MarshallingException, SignatureException,
     TransformerFactoryConfigurationError, TransformerException, ComponentInitializationException
   {
-    String serverurl = Utils.createOwnURLWithContextPath(req)
-                       + "/Metadata";
+    String serverurl = Utils.getMiddlewareServiceEntityId(req);
 
     EidasSigner signer = new EidasSigner(true, ConfigHolder.getAppSignatureKeyPair().getKey(),
                                          ConfigHolder.getAppSignatureKeyPair().getCert());

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
@@ -23,6 +23,11 @@ public class EidasSigner
 {
 
   /**
+   * The default hash algoritm. This value can be overridden by environment variable.
+   */
+  private static String defaultHashAlgo="SHA256-PSS";
+
+  /**
    * signature key
    */
   private final PrivateKey sigKey;
@@ -42,6 +47,11 @@ public class EidasSigner
    */
   private final SigEntryType sigType;
 
+  static {
+    String envHashSetting = System.getenv("EIDAS_SIGNER_DEFAULT_HASH_ALGORITHM");
+    defaultHashAlgo = envHashSetting != null ? envHashSetting : defaultHashAlgo;
+  }
+
   private EidasSigner(boolean includeCert, PrivateKey key, X509Certificate cert, String digestAlg)
   {
     if (key == null || cert == null || digestAlg == null)
@@ -60,14 +70,14 @@ public class EidasSigner
    * using a cert if a RSA Key or http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256 if using a cert with a
    * EC key. The canonicalization algorithm is set to http://www.w3.org/2001/10/xml-exc-c14n# and the digest
    * algorithm to http://www.w3.org/2001/04/xmlenc#sha256
-   * 
+   *
    * @param includeCert
    * @param key
    * @param cert
    */
   public EidasSigner(boolean includeCert, PrivateKey key, X509Certificate cert)
   {
-    this(includeCert, key, cert, "SHA256-PSS");
+    this(includeCert, key, cert, defaultHashAlgo);
   }
 
   EidasSigner(PrivateKey key, X509Certificate cert)

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso_template.xml
@@ -7,7 +7,7 @@
         <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
             <saml2:SubjectConfirmationData InResponseTo="$InResponseTo"
                 NotOnOrAfter="$NotOnOrAfter"
-                Recipient="$Recipient"/>
+                Recipient="$Destination"/>
         </saml2:SubjectConfirmation>
     </saml2:Subject>
     <saml2:Conditions NotBefore="$NotBefore" NotOnOrAfter="$NotOnOrAfter">

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/fail_resp_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/fail_resp_template.xml
@@ -9,5 +9,4 @@
     <saml2p:StatusCode Value="$Code"/>
     <saml2p:StatusMessage>$ErrMsg</saml2p:StatusMessage>
   </saml2p:Status>
-  $Assertion
 </saml2p:Response>

--- a/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/TestEidasSaml.java
+++ b/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/TestEidasSaml.java
@@ -11,6 +11,7 @@
 package de.governikus.eumw.eidasstarterkit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -295,7 +296,7 @@ public class TestEidasSaml
     EidasResponse result = EidasResponse.parse(new ByteArrayInputStream(response), keypair, cert);
 
     assertEquals(result.getDestination(), destination);
-    assertEquals(result.getNameId().getValue(), nameid.getValue());
+    assertNull(result.getNameId());
     assertEquals(result.getIssuer(), issuer);
     assertEquals(result.getInResponseTo(), inResponseTo);
 


### PR DESCRIPTION
The following PR contains the updates we have made to the middleware code in order to fix problems.

1) Docker file for including built code. As we have made some changes we needed a Docker file that is based on the build version rather than a downloaded jar. We also included the possibility to attach a remote debugger.

2) Fixed unsafe and unstable EntityID source. The service has no stable source of its own EntityID. The source is just the URL used to adress the service, which may differ from request to request. In particular with respect to inclusion or exclusion of port wen using standard port 443. When downloading metadata the EntityID is https://host/context/Metadata. When sending a response, the issuer is https://host:443/conext/Metadata. The result is that the response is sent from an unrecognised source and rejected. We added a possibility to set the EntityID from a fixed configured value. Here configured by Env variable passed at Docker run.

3) Fixed unsupported value for SubjectConfirmationData "Recipient" attribute.
While the SAML standard do allow this attribute to hold an EntityID of the recipient, most SAML profiles and SAML products expect, and enforce that this attribute holds the assertion consumer URL (The URL to which the response is sent). EntityID of the recipient is normally specified instead as AudienceRestriction. We updated the Assertion template to reflect this in order to make the Assertion compatible with most SAML consuming products.

In addition to this we would strongly recommend to replace the current code that generated SAML XML objects from text templates. It is very hard to ensure that such implementations are, and remains error free. Our opinion is that it would be more stable and secure approach to use OpenSAML 3 to generate SAML objects as this code is well tested and a good guarantee that the generated SAML objects are well formed and testable.