### PR TITLE
Updates 1.0.5 rc1

### DIFF
--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
@@ -23,6 +23,11 @@ public class EidasSigner
 {
 
   /**
+   * The default hash algoritm. This value can be overridden by environment variable.
+   */
+  private static String defaultHashAlgo="SHA256-PSS";
+
+  /**
    * signature key
    */
   private final PrivateKey sigKey;
@@ -42,6 +47,11 @@ public class EidasSigner
    */
   private final SigEntryType sigType;
 
+  static {
+    String envHashSetting = System.getenv("EIDAS_SIGNER_DEFAULT_HASH_ALGORITHM");
+    defaultHashAlgo = envHashSetting != null ? envHashSetting : defaultHashAlgo;
+  }
+
   private EidasSigner(boolean includeCert, PrivateKey key, X509Certificate cert, String digestAlg)
   {
     if (key == null || cert == null || digestAlg == null)
@@ -60,14 +70,14 @@ public class EidasSigner
    * using a cert if a RSA Key or http://www.w3.org/2001/04/xmldsig-more#ecdsa-sha256 if using a cert with a
    * EC key. The canonicalization algorithm is set to http://www.w3.org/2001/10/xml-exc-c14n# and the digest
    * algorithm to http://www.w3.org/2001/04/xmlenc#sha256
-   * 
+   *
    * @param includeCert
    * @param key
    * @param cert
    */
   public EidasSigner(boolean includeCert, PrivateKey key, X509Certificate cert)
   {
-    this(includeCert, key, cert, "SHA256-PSS");
+    this(includeCert, key, cert, defaultHashAlgo);
   }
 
   EidasSigner(PrivateKey key, X509Certificate cert)

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso_template.xml
@@ -7,12 +7,12 @@
         <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
             <saml2:SubjectConfirmationData InResponseTo="$InResponseTo"
                 NotOnOrAfter="$NotOnOrAfter"
-                Recipient="$Recipient"/>
+                Recipient="$Destination"/>
         </saml2:SubjectConfirmation>
     </saml2:Subject>
     <saml2:Conditions NotBefore="$NotBefore" NotOnOrAfter="$NotOnOrAfter">
         <saml2:AudienceRestriction>
-            <saml2:Audience>$Destination</saml2:Audience>
+            <saml2:Audience>$Recipient</saml2:Audience>
         </saml2:AudienceRestriction>
     </saml2:Conditions>
     <saml2:AuthnStatement AuthnInstant="$AuthnInstant"

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/fail_resp_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/fail_resp_template.xml
@@ -9,5 +9,4 @@
     <saml2p:StatusCode Value="$Code"/>
     <saml2p:StatusMessage>$ErrMsg</saml2p:StatusMessage>
   </saml2p:Status>
-  $Assertion
 </saml2p:Response>

--- a/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/TestEidasSaml.java
+++ b/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/TestEidasSaml.java
@@ -11,6 +11,7 @@
 package de.governikus.eumw.eidasstarterkit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -295,7 +296,7 @@ public class TestEidasSaml
     EidasResponse result = EidasResponse.parse(new ByteArrayInputStream(response), keypair, cert);
 
     assertEquals(result.getDestination(), destination);
-    assertEquals(result.getNameId().getValue(), nameid.getValue());
+    assertNull(result.getNameId());
     assertEquals(result.getIssuer(), issuer);
     assertEquals(result.getInResponseTo(), inResponseTo);
 


### PR DESCRIPTION
This pull request reflects all changes we made to 1.0.5 rc1 in order to make it work.

Please ignore the changes made to EidasSigner.java
We know that you deliberately do not want this change. We still need it however and as I learned today, another country needs it as well (Denmark).

The most important issue is that the fix in 1.0.5 rc1 with respect to AudienceRestriction is wrong and causes generation of invalid Assertions. See fix to asso_template.xml
The AudienceRestriction Recipient attribute should contain the assertion consumer URL. The AudienceRestriction should contain the EntityID.

We also insist that the error response should NOT contain an Assertion. We also insist that the current Assertion being generated in error responses contains a false ID. A string such as "Not available" is still an identifier for any non-human process.