### PR TITLE
Optionally sign assertions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+target/
+packer/
+*Jenkinsfile
+.hg/
+
+# IntelliJ project files
+*.iml
+*.iws
+*.ipr
+.idea/
+
+*/_build

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,9 @@ FROM maven:3.5.4-jdk-8-alpine as build
 WORKDIR /eumw
 USER root
 
+# Use settings.xml to override maven repos
+COPY settings.xml /usr/share/maven/ref/
+
 # Copy pom in first to get dependencies
 COPY pom.xml .
 COPY configuration-wizard/pom.xml configuration-wizard/pom.xml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,51 @@
+# Build stage
+FROM maven:3.5.4-jdk-8-alpine as build
+
+WORKDIR /eumw
+USER root
+
+# Copy pom in first to get dependencies
+COPY pom.xml .
+COPY configuration-wizard/pom.xml configuration-wizard/pom.xml
+COPY databasemigration/pom.xml databasemigration/pom.xml
+COPY eid-service/pom.xml eid-service/pom.xml
+COPY eidas-common/pom.xml eidas-common/pom.xml
+COPY eidas-demo/pom.xml eidas-demo/pom.xml
+COPY eidas-middleware/pom.xml eidas-middleware/pom.xml
+COPY eidas-starterkit/pom.xml eidas-starterkit/pom.xml
+COPY password-generator/pom.xml password-generator/pom.xml
+COPY poseidas-configuration/pom.xml poseidas-configuration/pom.xml
+COPY poseidas/pom.xml poseidas/pom.xml
+COPY utils/pom.xml utils/pom.xml
+RUN mvn dependency:go-offline --fail-never
+
+# Copy the rest
+COPY . .
+
+# Build
+RUN mvn install --projects eidas-middleware --also-make
+
+# Final image
+FROM governikus/eidas-base-container:1.0.6
+
+# Define the location of the configuration directory inside of the container
+ENV SPRING_CONFIG_ADDITIONAL_LOCATION=file:${CONFIG_DIR}/
+
+# Expose the ports we're interested in
+EXPOSE 8443
+
+# Fix the folder permissions because mounting with -v will mount with root
+RUN mkdir -p /opt/eidas-middleware/database &&\
+    chown eidas-middleware /opt/eidas-middleware/database &&\
+    chgrp eidas-middleware /opt/eidas-middleware/database
+
+# Change to the eidas user and directory
+USER eidas-middleware
+WORKDIR /opt/eidas-middleware
+
+# Copy the jar we built eariler
+COPY --from=build /eumw/eidas-middleware/target/eidas-middleware.jar .
+
+RUN mkdir -p ${CONFIG_DIR}
+
+ENTRYPOINT ["java", "-jar", "./eidas-middleware.jar"]

--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/ConfigHolder.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/ConfigHolder.java
@@ -114,6 +114,11 @@ public class ConfigHolder
   private static final String KEY_ORGANIZATION_DISPLAY_NAME = "ORGANIZATION_DISPLAY_NAME";
 
   /**
+   * Option to sign assertions
+   */
+  private static final String KEY_SHOULD_SIGN_ASSERTIONS = "SHOULD_SIGN_ASSERTIONS";
+
+  /**
    * Exception Messages
    */
   private static final String CAN_NOT_LOAD_SERVICE_DECRYPTION_CERT = "Can not load Service DecryptionCert";
@@ -372,4 +377,8 @@ public class ConfigHolder
     return ConfigHolder.holder.organization;
   }
 
+  public static synchronized boolean getShouldSignAssertions()
+  {
+    return Boolean.parseBoolean(ConfigHolder.holder.properties.getProperty(KEY_SHOULD_SIGN_ASSERTIONS, "false"));
+  }
 }

--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
@@ -436,7 +436,8 @@ public class ResponseSender extends HttpServlet
                                                 EidasLoA.HIGH,
                                                 samlReqSession.getReqId(),
                                                 encrypter,
-                                                signer);
+                                                signer,
+                                                ConfigHolder.getShouldSignAssertions());
     String content = WebServiceHelper.createForwardToConsumer(eidasResp, reqRelayState, null);
 
     HttpServerUtils.setPostContent(content, reqSP.getAssertionConsumerURL(), null, resp);

--- a/eidas-middleware/src/test/java/de/governikus/eumw/eidasmiddleware/EidasRoundTrip.java
+++ b/eidas-middleware/src/test/java/de/governikus/eumw/eidasmiddleware/EidasRoundTrip.java
@@ -151,7 +151,8 @@ public class EidasRoundTrip
                                           EidasLoA.LOW,
                                           "_inresp",
                                           new EidasEncrypter(true, keyPair2.getCert()),
-                                          signer);
+                                          signer,
+                                          false);
         s = new String(result, StandardCharsets.UTF_8);
         Assert.assertTrue(s != null);
         try (ByteArrayInputStream is = new ByteArrayInputStream(result))

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSaml.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSaml.java
@@ -263,6 +263,7 @@ public class EidasSaml
    * @param inResponseTo the responceTo id
    * @param encrypter the reader of the requested attributes
    * @param signer the author of this message
+   * @param shouldSignAssertions whether the assertions in the response should be signed
    * @return signed encrypted saml xml response as byte array
    * @throws ConfigurationException thrown if the opensaml lib or eidas starterkit lib is not init
    * @throws CertificateEncodingException thrown if there any problems with the used certificates
@@ -285,7 +286,8 @@ public class EidasSaml
                                       EidasLoA loa,
                                       String inResponseTo,
                                       EidasEncrypter encrypter,
-                                      EidasSigner signer)
+                                      EidasSigner signer,
+                                      boolean shouldSignAssertions)
     throws InitializationException, CertificateEncodingException, XMLParserException, IOException,
     UnmarshallingException, EncryptionException, MarshallingException, SignatureException,
     TransformerFactoryConfigurationError, TransformerException, ComponentInitializationException
@@ -293,7 +295,7 @@ public class EidasSaml
     init();
     EidasResponse response = new EidasResponse(att, destination, recipient, nameid, inResponseTo, issuer, loa,
                                                signer, encrypter);
-    return response.generate();
+    return response.generate(shouldSignAssertions);
   }
 
   /**

--- a/settings.xml
+++ b/settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <mirrors>
+    <mirror>
+      <id>artifactory</id>
+      <name>Verify Artifactory</name>
+      <url>https://artifactory.ida.digital.cabinet-office.gov.uk/artifactory</url>
+      <mirrorOf>central,bintray-governikus-public,jcenter</mirrorOf>
+    </mirror>
+  </mirrors>
+</settings>


### PR DESCRIPTION
The functionality of our SAML federation depends on having signed assertions from our identity providers, in this case the middleware. We understand that the middleware shouldn't sign assertions by default so we have added an optional flag to enable assertion signing. This should not affect the middleware's functionality in any other way.

- Added a flag to `eidasmiddleware.properties` called
`SHOULD_SIGN_ASSERTIONS` (defaults to *false*).
- If `SHOULD_SIGN_ASSERTIONS` is *true* then assertions in a successful
response returned by the middleware will be signed using the same
credentials as the response.
- Added test for signed/unsigned assertions.