### PR TITLE
Bugfix 1.0.6 Bad NameFormat URI

### DIFF
--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso.xml
@@ -25,13 +25,13 @@
     <saml2:AttributeStatement>
     <saml2:Attribute 
         FriendlyName="PersonIdentifier" 
-        Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas: PersonIdentifierType">
             ES/AT/02635542Y
         </saml2:AttributeValue>
     </saml2:Attribute>
     <saml2:Attribute 
-        FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue languageID="en-GR" xsi:type="eidas:CurrentFamilyNameType">
             Onasis
         </saml2:AttributeValue>        
@@ -42,14 +42,14 @@
     <saml2:Attribute 
         FriendlyName="FirstName" 
         Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue languageID="en-GB" xsi:type="eidas:CurrentGivenNameType">
             Sarah
         </saml2:AttributeValue>
     </saml2:Attribute>
     <saml2:Attribute 
         FriendlyName="DateOfBirth" 
-        Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:DateOfBirthType">
             1970-05-28
         </saml2:AttributeValue>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso2.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso2.xml
@@ -20,10 +20,10 @@
       </saml2:AuthnContext>
     </saml2:AuthnStatement>
     <saml2:AttributeStatement>
-      <saml2:Attribute FriendlyName="FamilyName" Name="FamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+      <saml2:Attribute FriendlyName="FamilyName" Name="FamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cva="http://www.w3.org/ns/corevocabulary/AggregateComponents" xmlns:cvb="http://www.w3.org/ns/corevocabulary/BasicComponents" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" languageID="de-DE" xsi:type="eidas:CurrentFamilyNameType">Meyer</saml2:AttributeValue>
       </saml2:Attribute>
-      <saml2:Attribute FriendlyName="FirstName" Name="FirstName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+      <saml2:Attribute FriendlyName="FirstName" Name="FirstName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cva="http://www.w3.org/ns/corevocabulary/AggregateComponents" xmlns:cvb="http://www.w3.org/ns/corevocabulary/BasicComponents" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" languageID="de-DE" xsi:type="eidas:CurrentGivenNameType">Hans</saml2:AttributeValue>
       </saml2:Attribute>
     </saml2:AttributeStatement>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/d201217euidentifier_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/d201217euidentifier_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="D-2012-17-EUIdentifier"
                 Name=" http://eidas.europa.eu/attributes/legalperson/D-2012-17-EUIdentifier"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:D-2012-17-EUIdentifierType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/dateOfBirth_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/dateOfBirth_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute 
         FriendlyName="DateOfBirth" 
-        Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:DateOfBirthType">$value</saml2:AttributeValue>
     </saml2:Attribute> 

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/eori_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/eori_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="EORI"
                 Name=" http://eidas.europa.eu/attributes/legalperson/EORI"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:EORIType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/familyname_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/familyname_template.xml
@@ -1,4 +1,4 @@
 <saml2:Attribute 
-        FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:CurrentFamilyNameType">$latinScript</saml2:AttributeValue>        
     </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/familyname_transliterated_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/familyname_transliterated_template.xml
@@ -1,4 +1,4 @@
-<saml2:Attribute FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+<saml2:Attribute FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 	<saml2:AttributeValue xsi:type="eidas:CurrentFamilyNameType">$latinScript</saml2:AttributeValue>  
 	<saml2:AttributeValue xsi:type="eidas:CurrentFamilyNameType" LatinScript="false">$nonLatinScript</saml2:AttributeValue>        
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/givenname_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/givenname_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
         FriendlyName="FirstName" 
         Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:CurrentGivenNameType">$latinScript</saml2:AttributeValue>
     </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/givenname_transliterated_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/givenname_transliterated_template.xml
@@ -1,4 +1,4 @@
-<saml2:Attribute FriendlyName="FirstName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+<saml2:Attribute FriendlyName="FirstName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 	<saml2:AttributeValue xsi:type="eidas:CurrentGivenNameType">$latinScript</saml2:AttributeValue>  
 	<saml2:AttributeValue xsi:type="eidas:CurrentGivenNameType" LatinScript="false">$nonLatinScript</saml2:AttributeValue>        
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalentityidentifier_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalentityidentifier_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="LEI"
                 Name=" http://eidas.europa.eu/attributes/legalperson/LEI"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:LEIType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalname_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalname_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="LegalName"
                 Name="http://eidas.europa.eu/attributes/legalperson/LegalName"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue languageID="en-GB" xsi:type="eidas:LegalNameType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalname_transliterated_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalname_transliterated_template.xml
@@ -1,4 +1,4 @@
-<saml2:Attribute FriendlyName="LegalName" Name="http://eidas.europa.eu/attributes/legalperson/LegalName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+<saml2:Attribute FriendlyName="LegalName" Name="http://eidas.europa.eu/attributes/legalperson/LegalName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 	<saml2:AttributeValue languageID="en-GB" xsi:type="eidas:LegalNameType">$latinScript</saml2:AttributeValue>
 	<saml2:AttributeValue xsi:type="eidas:LegalNameType" LatinScript="false">$nonLatinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalpersonaddress_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalpersonaddress_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="LegalAddress"
                 Name="http://eidas.europa.eu/attributes/legalperson/LegalPersonAddress"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:LegalPersonAddressType">$base64Value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/personId_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/personId_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute 
         FriendlyName="PersonIdentifier" 
-        Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:PersonIdentifierType">$value</saml2:AttributeValue>
     </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/placeOfBirth_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/placeOfBirth_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="PlaceOfBirth" 
 Name=" http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth"
-NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:PlaceOfBirthType">$value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/seed_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/seed_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="SEED"
                 Name=" http://eidas.europa.eu/attributes/legalperson/SEED"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:SEEDType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/sic_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/sic_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="SIC"
                 Name=" http://eidas.europa.eu/attributes/legalperson/SIC"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:SICType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/taxreference_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/taxreference_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="TaxReference"
                 Name="http://eidas.europa.eu/attributes/legalperson/TaxReference"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:TaxReferenceType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/vatregistration_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/vatregistration_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="VATRegistration"
                 Name="http://eidas.europa.eu/attributes/legalperson/VATRegistrationNumber"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:VATRegistrationNumberType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>


### PR DESCRIPTION
As noted by Petri Suliva from Finland, the middleware implementation provide Assertions with illegal NameFormat declaration.

Several attributes incorrectly declare `NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri"`

This should be `NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri"`

This problem is corrected in this PR.