### PR TITLE
RelayState fix in 1.0.6

### DIFF
--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/RequestReceiver.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/RequestReceiver.java
@@ -111,11 +111,10 @@ public class RequestReceiver extends HttpServlet
 
     try
     {
-      if (request.getParameter(HttpRedirectUtils.RELAYSTATE_PARAMNAME) == null
-          || request.getParameter(HttpRedirectUtils.REQUEST_PARAMNAME) == null)
+      if (request.getParameter(HttpRedirectUtils.REQUEST_PARAMNAME) == null)
       {
         throw new ErrorCodeException(ErrorCode.ILLEGAL_REQUEST_SYNTAX,
-                                     "Query Parameter 'RelayState' or 'SAMLRequest' is missing");
+                                     "Query Parameter 'SAMLRequest' is missing");
       }
       String relayState = request.getParameter(HttpRedirectUtils.RELAYSTATE_PARAMNAME);
       String samlRequestBase64 = request.getParameter(HttpRedirectUtils.REQUEST_PARAMNAME);


### PR DESCRIPTION
RelayState is optional in SAML. However. the Middleware code fails if no RelayState is received.

This PR provides an easy fix by removing the test for absent RelayState in the request.

The MW code can handle an absent RelayState fairly well with this simple fix. It will return an empty RelayState. Ideally this fix should be extended to respond with an absent RelayState parameter instead of an empty one.