### PR TITLE
Removing carriage return characters from SAML responses

### DIFF
--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
@@ -14,6 +14,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;
@@ -33,6 +34,7 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import net.shibboleth.utilities.java.support.xml.SerializeSupport;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.Marshaller;
@@ -233,6 +235,8 @@ public class EidasResponse
       Signer.signObjects(sigs);
 
       openSamlResp = resp;
+      returnValue = getResonseBytes();
+/*
       Transformer trans = TransformerFactory.newInstance().newTransformer();
       trans.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
       // Please note: you cannot format the output without breaking signature!
@@ -241,6 +245,7 @@ public class EidasResponse
         trans.transform(new DOMSource(all), new StreamResult(bout));
         returnValue = bout.toByteArray();
       }
+*/
     }
     return returnValue;
   }
@@ -341,6 +346,9 @@ public class EidasResponse
       Signer.signObjects(sigs);
 
       openSamlResp = resp;
+      returnValue = getResonseBytes();
+
+/*
       Transformer trans = TransformerFactory.newInstance().newTransformer();
       trans.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
       // Please note: you cannot format the output without breaking signature!
@@ -349,9 +357,17 @@ public class EidasResponse
         trans.transform(new DOMSource(all), new StreamResult(bout));
         returnValue = bout.toByteArray();
       }
+*/
     }
     return returnValue;
   }
+
+  private byte[] getResonseBytes() throws MarshallingException {
+      Element responseElm = XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(openSamlResp).marshall(openSamlResp);
+      return SerializeSupport.nodeToString(responseElm).getBytes(Charset.forName("UTF-8"));
+  }
+
+
 
   public String getId()
   {

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
@@ -14,7 +14,6 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.security.cert.CertificateEncodingException;
 import java.security.cert.X509Certificate;

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
@@ -235,7 +235,6 @@ public class EidasResponse
       Signer.signObjects(sigs);
 
       openSamlResp = resp;
-      returnValue = getResonseBytes();
 
       Transformer trans = TransformerFactory.newInstance().newTransformer();
       trans.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
@@ -243,6 +242,7 @@ public class EidasResponse
       try (ByteArrayOutputStream bout = new ByteArrayOutputStream())
       {
         trans.transform(new DOMSource(all), new StreamResult(bout));
+        returnValue = stripCR(bout.toByteArray());
       }
     }
     return returnValue;
@@ -318,7 +318,6 @@ public class EidasResponse
       Unmarshaller unmarshaller = unmarshallerFactory.getUnmarshaller(metadataRoot);
       Response resp = (Response)unmarshaller.unmarshall(metadataRoot);
 
-                                       signer.getSigKey(),
       for ( Assertion a : assertions )
       {
         a.setParent(null);

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
@@ -234,7 +234,6 @@ public class EidasResponse
       Signer.signObjects(sigs);
 
       openSamlResp = resp;
-
       Transformer trans = TransformerFactory.newInstance().newTransformer();
       trans.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
       // Please note: you cannot format the output without breaking signature!
@@ -348,7 +347,6 @@ public class EidasResponse
       Signer.signObjects(sigs);
 
       openSamlResp = resp;
-
       Transformer trans = TransformerFactory.newInstance().newTransformer();
       trans.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
       // Please note: you cannot format the output without breaking signature!
@@ -639,14 +637,10 @@ public class EidasResponse
 
   private static String getAudience(Response resp) throws ErrorCodeException
   {
-    if (resp.getAssertions().isEmpty()){
-      // The process below is only applicable when the response contains at least one Assertion element.
-      return null;
-    }
     return resp.getAssertions()
                .stream()
                .findFirst()
-               .orElseThrow(() -> new ErrorCodeException(ErrorCode.ERROR, "Expected Assertion in response."))
+               .orElseThrow(() -> new ErrorCodeException(ErrorCode.ERROR, "Missing Assertion in response."))
                .getConditions()
                .getAudienceRestrictions()
                .stream()


### PR DESCRIPTION
The responses from the middleware contains CR "carriage return" (ASCII 13) characters at several base64 block line endings, but nowhere else.

These may be challenging in signature validation processes as they are represented in XML using at least 3 different character sequences (html entities) "&amp;#13;", "&#xD" or "&#xd".

Correctly implemented XML transform algoritms should be able to handle this, but there are indications that some don't handle this very well. The safest option would be to remove CR characters all together from SAML responses, in particular since it is not used consistently, but just added to base64 encoded blocks of data.

This PR demonstrates a quick fix to remove CR.

I do not recommend to use this quick fix, as it only removes the CR characters that should not been added in the first place. An appropriate fix would get to the bottom of the issue and resolve the cause why CR was added in the first place to base64 encoded data blocks in responses.

