### PR TITLE
DK response updates

### DIFF
--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
@@ -55,6 +55,7 @@ import de.governikus.eumw.eidasstarterkit.EidasNaturalPersonAttributes;
 import de.governikus.eumw.eidasstarterkit.EidasResponse;
 import de.governikus.eumw.eidasstarterkit.EidasSaml;
 import de.governikus.eumw.eidasstarterkit.EidasSigner;
+import de.governikus.eumw.eidasstarterkit.EidasPersistentNameId;
 import de.governikus.eumw.eidasstarterkit.EidasTransientNameId;
 import de.governikus.eumw.eidasstarterkit.person_attributes.natural_persons_attribute.BirthNameAttribute;
 import de.governikus.eumw.eidasstarterkit.person_attributes.natural_persons_attribute.CurrentAddressAttribute;
@@ -285,7 +286,9 @@ public class ResponseSender extends HttpServlet
                                                                    + Hex.encodeHexString(restrID.getID1())
                                                                         .toUpperCase(Locale.GERMANY));
       attributes.add(pi);
-      nameId = new EidasTransientNameId(pi.getId());
+      //Using persistent Name ID as PersonIdentifier is a persistent identifier.
+      //Ideally this should be checking the SP metadata whether the selected format is requested.
+      nameId = new EidasPersistentNameId(pi.getId());
     }
 
     prepareSAMLResponse(req, resp, reqSP, samlReqSession, reqRelayState, attributes, nameId);

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
@@ -268,6 +268,7 @@ public class EidasResponse
     }
     String assoTemp = TemplateLoader.getTemplateByName("asso");
     assoTemp = assoTemp.replace("$NameFormat", nameId.getType().value);
+    assoTemp = assoTemp.replace("$NameQualifier", issuer);
     assoTemp = assoTemp.replace("$NameID", nameId.getValue());
     assoTemp = assoTemp.replace("$AssertionId", "_" + Utils.generateUniqueID());
     assoTemp = assoTemp.replace("$Recipient", recipient);

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/person_attributes/natural_persons_attribute/CurrentAddressAttribute.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/person_attributes/natural_persons_attribute/CurrentAddressAttribute.java
@@ -31,15 +31,15 @@ import de.governikus.eumw.eidasstarterkit.template.TemplateLoader;
 public class CurrentAddressAttribute implements EidasAttribute
 {
 
-  private static final String CV_ADDRESS_TEMP = "<eidas:LocatorDesignator>$locatorDesignator</eidas:LocatorDesignator>"
-                                                + "<eidas:Thoroughfare>$thoroughfare</eidas:Thoroughfare>"
-                                                + "<eidas:PostName>$postName</eidas:PostName>"
-                                                + "<eidas:PostCode>$postCode</eidas:PostCode>"
-                                                + "<eidas:PoBox>$pOBOX</eidas:PoBox>"
+  private static final String CV_ADDRESS_TEMP = "<eidas:PoBox>$pOBOX</eidas:PoBox>"
+                                                +"<eidas:LocatorDesignator>$locatorDesignator</eidas:LocatorDesignator>"
                                                 + "<eidas:LocatorName>$locatorName</eidas:LocatorName>"
                                                 + "<eidas:CvaddressArea>$cvaddressArea</eidas:CvaddressArea>"
+                                                + "<eidas:Thoroughfare>$thoroughfare</eidas:Thoroughfare>"
+                                                + "<eidas:PostName>$postName</eidas:PostName>"
                                                 + "<eidas:AdminunitFirstline>$adminunitFirstline</eidas:AdminunitFirstline>"
-                                                + "<eidas:AdminunitSecondline>$adminunitSecondline</eidas:AdminunitSecondline>";
+                                                + "<eidas:AdminunitSecondline>$adminunitSecondline</eidas:AdminunitSecondline>"
+                                                + "<eidas:PostCode>$postCode</eidas:PostCode>";
 
   private String locatorDesignator;
 

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso_template.xml
@@ -3,7 +3,7 @@
     xmlns:eidas="http://eidas.europa.eu/attributes/naturalperson">
     <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">$Issuer</saml2:Issuer>
     <saml2:Subject>
-        <saml2:NameID Format="$NameFormat">$NameID</saml2:NameID>
+        <saml2:NameID Format="$NameFormat" NameQualifier="$NameQualifier">$NameID</saml2:NameID>
         <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
             <saml2:SubjectConfirmationData InResponseTo="$InResponseTo"
                 NotOnOrAfter="$NotOnOrAfter"

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/birthName_Template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/birthName_Template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="BirthName" 
-Name=" http://eidas.europa.eu/attributes/naturalperson/BirthName"
+Name="http://eidas.europa.eu/attributes/naturalperson/BirthName"
 NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:BirthNameType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/birthName_transliterated_Template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/birthName_transliterated_Template.xml
@@ -1,4 +1,4 @@
-<saml2:Attribute FriendlyName="BirthName" Name=" http://eidas.europa.eu/attributes/naturalperson/BirthName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+<saml2:Attribute FriendlyName="BirthName" Name="http://eidas.europa.eu/attributes/naturalperson/BirthName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 	<saml2:AttributeValue xsi:type="eidas:BirthNameType">$latinScript</saml2:AttributeValue>
 	<saml2:AttributeValue xsi:type="eidas:BirthNameType" LatinScript="false">$nonLatinScript</saml2:AttributeValue>  
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/currentaddress_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/currentaddress_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="CurrentAddress" 
-Name=" http://eidas.europa.eu/attributes/naturalperson/CurrentAddress"
+Name="http://eidas.europa.eu/attributes/naturalperson/CurrentAddress"
 NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:CurrentAddressType">$value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/d201217euidentifier_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/d201217euidentifier_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="D-2012-17-EUIdentifier"
-                Name=" http://eidas.europa.eu/attributes/legalperson/D-2012-17-EUIdentifier"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/D-2012-17-EUIdentifier"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:D-2012-17-EUIdentifierType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/eori_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/eori_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="EORI"
-                Name=" http://eidas.europa.eu/attributes/legalperson/EORI"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/EORI"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:EORIType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/gender_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/gender_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="Gender" 
-Name=" http://eidas.europa.eu/attributes/naturalperson/Gender"
+Name="http://eidas.europa.eu/attributes/naturalperson/Gender"
 NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:GenderType">$value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalentityidentifier_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalentityidentifier_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="LEI"
-                Name=" http://eidas.europa.eu/attributes/legalperson/LEI"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/LEI"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:LEIType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/placeOfBirth_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/placeOfBirth_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="PlaceOfBirth" 
-Name=" http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth"
-NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+Name="http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth"
+NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:PlaceOfBirthType">$value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/resp_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/resp_template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<saml2p:Response Destination="$Destination"
+<saml2p:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:obtained" Destination="$Destination"
   ID="$Id" InResponseTo="$InResponseTo"
   IssueInstant="$IssueInstant" Version="2.0"
   xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/seed_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/seed_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="SEED"
-                Name=" http://eidas.europa.eu/attributes/legalperson/SEED"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/SEED"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:SEEDType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/sic_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/sic_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="SIC"
-                Name=" http://eidas.europa.eu/attributes/legalperson/SIC"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/SIC"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:SICType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>


### PR DESCRIPTION
This PR provides changes that was necessary in order to align the DE middleware with the DK validation rules for SAML responses. The following issues were addressed:

1. No "Consent" attribute is set in the Response root element.
2. Subject in the Assertion provided a transient NameID despite connector request NameIDPolixy requiring persistent NameID
3. Added NameQualifier to Subject NameID (which is generally provided).

Item number 3 turned out to not be necessary but it is kept in here as it is good practice.

The solution provided to 2 in this PR is not ideal. It would ideally take into account what the requesting service has declared as requirement and preferences and deliver accordingly, or send an error response.
