### PR TITLE
Various updates to 1.0.7

### DIFF
--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/RequestReceiver.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/RequestReceiver.java
@@ -106,10 +106,10 @@ public class RequestReceiver extends HttpServlet
       String relayState = request.getParameter(HttpRedirectUtils.RELAYSTATE_PARAMNAME);
       String samlRequestBase64 = request.getParameter(HttpRedirectUtils.REQUEST_PARAMNAME);
 
-      if (relayState == null || samlRequestBase64 == null)
+      if (samlRequestBase64 == null)
       {
         throw new ErrorCodeException(ErrorCode.ILLEGAL_REQUEST_SYNTAX,
-                                     "Query Parameter 'RelayState' or 'SAMLRequest' is missing");
+                                     "Query Parameter 'SAMLRequest' is missing");
       }
 
       byte[] samlRequest = getSAMLRequestBytes(isPost, samlRequestBase64);

--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/servlet/ResponseSender.java
@@ -55,6 +55,7 @@ import de.governikus.eumw.eidasstarterkit.EidasNaturalPersonAttributes;
 import de.governikus.eumw.eidasstarterkit.EidasResponse;
 import de.governikus.eumw.eidasstarterkit.EidasSaml;
 import de.governikus.eumw.eidasstarterkit.EidasSigner;
+import de.governikus.eumw.eidasstarterkit.EidasPersistentNameId;
 import de.governikus.eumw.eidasstarterkit.EidasTransientNameId;
 import de.governikus.eumw.eidasstarterkit.person_attributes.natural_persons_attribute.BirthNameAttribute;
 import de.governikus.eumw.eidasstarterkit.person_attributes.natural_persons_attribute.CurrentAddressAttribute;
@@ -285,7 +286,9 @@ public class ResponseSender extends HttpServlet
                                                                    + Hex.encodeHexString(restrID.getID1())
                                                                         .toUpperCase(Locale.GERMANY));
       attributes.add(pi);
-      nameId = new EidasTransientNameId(pi.getId());
+      //Using persistent Name ID as PersonIdentifier is a persistent identifier.
+      //Ideally this should be checking the SP metadata whether the selected format is requested.
+      nameId = new EidasPersistentNameId(pi.getId());
     }
 
     prepareSAMLResponse(req, resp, reqSP, samlReqSession, reqRelayState, attributes, nameId);

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
@@ -32,6 +32,7 @@ import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 
+import net.shibboleth.utilities.java.support.xml.SerializeSupport;
 import org.opensaml.core.xml.XMLObject;
 import org.opensaml.core.xml.config.XMLObjectProviderRegistrySupport;
 import org.opensaml.core.xml.io.Marshaller;
@@ -158,28 +159,6 @@ public class EidasResponse
   {
     BasicParserPool ppMgr = Utils.getBasicParserPool();
     byte[] returnValue;
-    String notBefore = Constants.format(new Date());
-    String notAfter = Constants.format(new Date(new Date().getTime() + (10 * ONE_MINUTE_IN_MILLIS)));
-
-    String assoTemp = TemplateLoader.getTemplateByName("failasso");
-
-    if (nameId == null)
-    {
-      nameId = new EidasTransientNameId("Error in process, therefore no NameID");
-    }
-
-    assoTemp = assoTemp.replace("$AssertionId", "_" + Utils.generateUniqueID());
-    assoTemp = assoTemp.replace("$IssueInstant", issueInstant);
-    assoTemp = assoTemp.replace("$Issuer", issuer);
-    assoTemp = assoTemp.replace("$NameFormat", nameId.getType().value);
-    assoTemp = assoTemp.replace("$NameID", nameId.getValue());
-    assoTemp = assoTemp.replace("$InResponseTo", inResponseTo);
-    assoTemp = assoTemp.replace("$NotOnOrAfter", notAfter);
-    assoTemp = assoTemp.replace("$Recipient", recipient);
-    assoTemp = assoTemp.replace("$NotBefore", notBefore);
-
-    assoTemp = assoTemp.replace("$AuthnInstant", issueInstant);
-    assoTemp = assoTemp.replace("$LoA", loa.value);
 
     String respTemp = TemplateLoader.getTemplateByName("failresp");
     respTemp = respTemp.replace("$InResponseTo", inResponseTo);
@@ -196,7 +175,6 @@ public class EidasResponse
     {
       respTemp = respTemp.replace("$ErrMsg", code.toDescription(msg));
     }
-    respTemp = respTemp.replace("$Assertion", assoTemp);
 
     List<Signature> sigs = new ArrayList<>();
 
@@ -236,7 +214,7 @@ public class EidasResponse
       try (ByteArrayOutputStream bout = new ByteArrayOutputStream())
       {
         trans.transform(new DOMSource(all), new StreamResult(bout));
-        returnValue = bout.toByteArray();
+        returnValue = stripCR(bout.toByteArray());
       }
     }
     return returnValue;
@@ -262,6 +240,7 @@ public class EidasResponse
     }
     String assoTemp = TemplateLoader.getTemplateByName("asso");
     assoTemp = assoTemp.replace("$NameFormat", nameId.getType().value);
+    assoTemp = assoTemp.replace("$NameQualifier", issuer);
     assoTemp = assoTemp.replace("$NameID", nameId.getValue());
     assoTemp = assoTemp.replace("$AssertionId", "_" + Utils.generateUniqueID());
     assoTemp = assoTemp.replace("$Recipient", recipient);
@@ -310,16 +289,21 @@ public class EidasResponse
       Unmarshaller unmarshaller = unmarshallerFactory.getUnmarshaller(metadataRoot);
       Response resp = (Response)unmarshaller.unmarshall(metadataRoot);
 
-      XMLSignatureHandler.addSignature(resp,
-                                       signer.getSigKey(),
-                                       signer.getSigCert(),
-                                       signer.getSigType(),
-                                       signer.getSigDigestAlg());
       for ( Assertion a : assertions )
       {
         a.setParent(null);
         resp.getEncryptedAssertions().add(this.encrypter.encrypter.encrypt(a));
       }
+
+      //Removing CR
+      resp = removeAllCarigeReturnElements(resp, ppMgr);
+
+      //Add signature object after the Encrypted assertions are added and CR characters removed.
+      XMLSignatureHandler.addSignature(resp,
+              signer.getSigKey(),
+              signer.getSigCert(),
+              signer.getSigType(),
+              signer.getSigDigestAlg());
 
       if (resp.getSignature() != null)
       {
@@ -342,11 +326,40 @@ public class EidasResponse
       try (ByteArrayOutputStream bout = new ByteArrayOutputStream())
       {
         trans.transform(new DOMSource(all), new StreamResult(bout));
-        returnValue = bout.toByteArray();
+        //Remove CR from signature value
+        returnValue = stripCR(bout.toByteArray());
       }
     }
     return returnValue;
   }
+
+  private Response removeAllCarigeReturnElements(Response response, BasicParserPool ppMgr) throws IOException, XMLParserException, UnmarshallingException, MarshallingException {
+
+    Marshaller rm = XMLObjectProviderRegistrySupport.getMarshallerFactory().getMarshaller(response.getElementQName());
+    String responseStr = stripCR(SerializeSupport.nodeToString(rm.marshall(response)));
+
+    try (InputStream is = new ByteArrayInputStream(responseStr.getBytes(StandardCharsets.UTF_8)))
+    {
+      Document inCommonMDDoc = ppMgr.parse(is);
+      Element responseElement = inCommonMDDoc.getDocumentElement();
+      // Get apropriate unmarshaller
+      UnmarshallerFactory unmarshallerFactory = XMLObjectProviderRegistrySupport.getUnmarshallerFactory();
+      Unmarshaller unmarshaller = unmarshallerFactory.getUnmarshaller(responseElement);
+      return  (Response)unmarshaller.unmarshall(responseElement);
+    }
+
+  }
+
+  private String stripCR (String stringWithCrEntity){
+    String stripped = stringWithCrEntity.replaceAll("&#13;","").replaceAll("&#xd;","").replaceAll("&#xD;","");
+    return stripped;
+  }
+
+  private byte[] stripCR(byte[] toByteArray) {
+    return stripCR(new String (toByteArray, StandardCharsets.UTF_8)).getBytes(StandardCharsets.UTF_8);
+  }
+
+
 
   public String getId()
   {
@@ -595,10 +608,14 @@ public class EidasResponse
 
   private static String getAudience(Response resp) throws ErrorCodeException
   {
+    if (resp.getAssertions().isEmpty()){
+      // The process below is only applicable when the response contains at least one Assertion element.
+      return null;
+    }
     return resp.getAssertions()
                .stream()
                .findFirst()
-               .orElseThrow(() -> new ErrorCodeException(ErrorCode.ERROR, "Missing Assertion in response."))
+               .orElseThrow(() -> new ErrorCodeException(ErrorCode.ERROR, "Expected Assertion in response."))
                .getConditions()
                .getAudienceRestrictions()
                .stream()

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasSigner.java
@@ -21,6 +21,10 @@ import de.governikus.eumw.eidasstarterkit.XMLSignatureHandler.SigEntryType;
  */
 public class EidasSigner
 {
+  /**
+   * The default hash algoritm. This value can be overridden by environment variable.
+   */
+  private static String defaultHashAlgo="SHA256-PSS";
 
   /**
    * signature key
@@ -41,6 +45,11 @@ public class EidasSigner
    * specifies whether to sign and whether to include the signature certificate
    */
   private final SigEntryType sigType;
+
+  static {
+    String envHashSetting = System.getenv("EIDAS_SIGNER_DEFAULT_HASH_ALGORITHM");
+    defaultHashAlgo = envHashSetting != null ? envHashSetting : defaultHashAlgo;
+  }
 
   private EidasSigner(boolean includeCert, PrivateKey key, X509Certificate cert, String digestAlg)
   {
@@ -67,7 +76,7 @@ public class EidasSigner
    */
   public EidasSigner(boolean includeCert, PrivateKey key, X509Certificate cert)
   {
-    this(includeCert, key, cert, "SHA256-PSS");
+    this(includeCert, key, cert, defaultHashAlgo);
   }
 
   EidasSigner(PrivateKey key, X509Certificate cert)

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/person_attributes/natural_persons_attribute/CurrentAddressAttribute.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/person_attributes/natural_persons_attribute/CurrentAddressAttribute.java
@@ -31,15 +31,15 @@ import de.governikus.eumw.eidasstarterkit.template.TemplateLoader;
 public class CurrentAddressAttribute implements EidasAttribute
 {
 
-  private static final String CV_ADDRESS_TEMP = "<eidas:LocatorDesignator>$locatorDesignator</eidas:LocatorDesignator>"
-                                                + "<eidas:Thoroughfare>$thoroughfare</eidas:Thoroughfare>"
-                                                + "<eidas:PostName>$postName</eidas:PostName>"
-                                                + "<eidas:PostCode>$postCode</eidas:PostCode>"
-                                                + "<eidas:PoBox>$pOBOX</eidas:PoBox>"
+  private static final String CV_ADDRESS_TEMP = "<eidas:PoBox>$pOBOX</eidas:PoBox>"
+                                                +"<eidas:LocatorDesignator>$locatorDesignator</eidas:LocatorDesignator>"
                                                 + "<eidas:LocatorName>$locatorName</eidas:LocatorName>"
                                                 + "<eidas:CvaddressArea>$cvaddressArea</eidas:CvaddressArea>"
+                                                + "<eidas:Thoroughfare>$thoroughfare</eidas:Thoroughfare>"
+                                                + "<eidas:PostName>$postName</eidas:PostName>"
                                                 + "<eidas:AdminunitFirstline>$adminunitFirstline</eidas:AdminunitFirstline>"
-                                                + "<eidas:AdminunitSecondline>$adminunitSecondline</eidas:AdminunitSecondline>";
+                                                + "<eidas:AdminunitSecondline>$adminunitSecondline</eidas:AdminunitSecondline>"
+                                                + "<eidas:PostCode>$postCode</eidas:PostCode>";
 
   private String locatorDesignator;
 

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso.xml
@@ -25,13 +25,13 @@
     <saml2:AttributeStatement>
     <saml2:Attribute 
         FriendlyName="PersonIdentifier" 
-        Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas: PersonIdentifierType">
             ES/AT/02635542Y
         </saml2:AttributeValue>
     </saml2:Attribute>
     <saml2:Attribute 
-        FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue languageID="en-GR" xsi:type="eidas:CurrentFamilyNameType">
             Onasis
         </saml2:AttributeValue>        
@@ -42,14 +42,14 @@
     <saml2:Attribute 
         FriendlyName="FirstName" 
         Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue languageID="en-GB" xsi:type="eidas:CurrentGivenNameType">
             Sarah
         </saml2:AttributeValue>
     </saml2:Attribute>
     <saml2:Attribute 
         FriendlyName="DateOfBirth" 
-        Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:DateOfBirthType">
             1970-05-28
         </saml2:AttributeValue>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso2.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso2.xml
@@ -20,10 +20,10 @@
       </saml2:AuthnContext>
     </saml2:AuthnStatement>
     <saml2:AttributeStatement>
-      <saml2:Attribute FriendlyName="FamilyName" Name="FamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+      <saml2:Attribute FriendlyName="FamilyName" Name="FamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cva="http://www.w3.org/ns/corevocabulary/AggregateComponents" xmlns:cvb="http://www.w3.org/ns/corevocabulary/BasicComponents" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" languageID="de-DE" xsi:type="eidas:CurrentFamilyNameType">Meyer</saml2:AttributeValue>
       </saml2:Attribute>
-      <saml2:Attribute FriendlyName="FirstName" Name="FirstName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+      <saml2:Attribute FriendlyName="FirstName" Name="FirstName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" xmlns:cva="http://www.w3.org/ns/corevocabulary/AggregateComponents" xmlns:cvb="http://www.w3.org/ns/corevocabulary/BasicComponents" xmlns:ext="urn:oasis:names:specification:ubl:schema:xsd:CommonExtensionComponents-2" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" languageID="de-DE" xsi:type="eidas:CurrentGivenNameType">Hans</saml2:AttributeValue>
       </saml2:Attribute>
     </saml2:AttributeStatement>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/asso_template.xml
@@ -3,7 +3,7 @@
     xmlns:eidas="http://eidas.europa.eu/attributes/naturalperson">
     <saml2:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity">$Issuer</saml2:Issuer>
     <saml2:Subject>
-        <saml2:NameID Format="$NameFormat">$NameID</saml2:NameID>
+        <saml2:NameID Format="$NameFormat" NameQualifier="$NameQualifier">$NameID</saml2:NameID>
         <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
             <saml2:SubjectConfirmationData InResponseTo="$InResponseTo"
                 NotOnOrAfter="$NotOnOrAfter"

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/birthName_Template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/birthName_Template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="BirthName" 
-Name=" http://eidas.europa.eu/attributes/naturalperson/BirthName"
+Name="http://eidas.europa.eu/attributes/naturalperson/BirthName"
 NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:BirthNameType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/birthName_transliterated_Template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/birthName_transliterated_Template.xml
@@ -1,4 +1,4 @@
-<saml2:Attribute FriendlyName="BirthName" Name=" http://eidas.europa.eu/attributes/naturalperson/BirthName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
+<saml2:Attribute FriendlyName="BirthName" Name="http://eidas.europa.eu/attributes/naturalperson/BirthName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 	<saml2:AttributeValue xsi:type="eidas:BirthNameType">$latinScript</saml2:AttributeValue>
 	<saml2:AttributeValue xsi:type="eidas:BirthNameType" LatinScript="false">$nonLatinScript</saml2:AttributeValue>  
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/currentaddress_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/currentaddress_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="CurrentAddress" 
-Name=" http://eidas.europa.eu/attributes/naturalperson/CurrentAddress"
+Name="http://eidas.europa.eu/attributes/naturalperson/CurrentAddress"
 NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:CurrentAddressType">$value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/d201217euidentifier_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/d201217euidentifier_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="D-2012-17-EUIdentifier"
-                Name=" http://eidas.europa.eu/attributes/legalperson/D-2012-17-EUIdentifier"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/D-2012-17-EUIdentifier"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:D-2012-17-EUIdentifierType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/dateOfBirth_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/dateOfBirth_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute 
         FriendlyName="DateOfBirth" 
-        Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        Name="http://eidas.europa.eu/attributes/naturalperson/DateOfBirth" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:DateOfBirthType">$value</saml2:AttributeValue>
     </saml2:Attribute> 

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/eori_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/eori_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="EORI"
-                Name=" http://eidas.europa.eu/attributes/legalperson/EORI"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/EORI"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:EORIType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/fail_resp_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/fail_resp_template.xml
@@ -9,5 +9,4 @@
     <saml2p:StatusCode Value="$Code"/>
     <saml2p:StatusMessage>$ErrMsg</saml2p:StatusMessage>
   </saml2p:Status>
-  $Assertion
 </saml2p:Response>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/familyname_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/familyname_template.xml
@@ -1,4 +1,4 @@
 <saml2:Attribute 
-        FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:CurrentFamilyNameType">$latinScript</saml2:AttributeValue>        
     </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/familyname_transliterated_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/familyname_transliterated_template.xml
@@ -1,4 +1,4 @@
-<saml2:Attribute FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+<saml2:Attribute FriendlyName="FamilyName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentFamilyName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 	<saml2:AttributeValue xsi:type="eidas:CurrentFamilyNameType">$latinScript</saml2:AttributeValue>  
 	<saml2:AttributeValue xsi:type="eidas:CurrentFamilyNameType" LatinScript="false">$nonLatinScript</saml2:AttributeValue>        
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/gender_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/gender_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="Gender" 
-Name=" http://eidas.europa.eu/attributes/naturalperson/Gender"
+Name="http://eidas.europa.eu/attributes/naturalperson/Gender"
 NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:GenderType">$value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/givenname_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/givenname_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
         FriendlyName="FirstName" 
         Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName"
-        NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:CurrentGivenNameType">$latinScript</saml2:AttributeValue>
     </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/givenname_transliterated_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/givenname_transliterated_template.xml
@@ -1,4 +1,4 @@
-<saml2:Attribute FriendlyName="FirstName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+<saml2:Attribute FriendlyName="FirstName" Name="http://eidas.europa.eu/attributes/naturalperson/CurrentGivenName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 	<saml2:AttributeValue xsi:type="eidas:CurrentGivenNameType">$latinScript</saml2:AttributeValue>  
 	<saml2:AttributeValue xsi:type="eidas:CurrentGivenNameType" LatinScript="false">$nonLatinScript</saml2:AttributeValue>        
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalentityidentifier_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalentityidentifier_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="LEI"
-                Name=" http://eidas.europa.eu/attributes/legalperson/LEI"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/LEI"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:LEIType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalname_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalname_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="LegalName"
                 Name="http://eidas.europa.eu/attributes/legalperson/LegalName"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue languageID="en-GB" xsi:type="eidas:LegalNameType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalname_transliterated_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalname_transliterated_template.xml
@@ -1,4 +1,4 @@
-<saml2:Attribute FriendlyName="LegalName" Name="http://eidas.europa.eu/attributes/legalperson/LegalName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+<saml2:Attribute FriendlyName="LegalName" Name="http://eidas.europa.eu/attributes/legalperson/LegalName" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 	<saml2:AttributeValue languageID="en-GB" xsi:type="eidas:LegalNameType">$latinScript</saml2:AttributeValue>
 	<saml2:AttributeValue xsi:type="eidas:LegalNameType" LatinScript="false">$nonLatinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalpersonaddress_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/legalpersonaddress_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="LegalAddress"
                 Name="http://eidas.europa.eu/attributes/legalperson/LegalPersonAddress"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:LegalPersonAddressType">$base64Value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/personId_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/personId_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute 
         FriendlyName="PersonIdentifier" 
-        Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+        Name="http://eidas.europa.eu/attributes/naturalperson/PersonIdentifier" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
         <saml2:AttributeValue xsi:type="eidas:PersonIdentifierType">$value</saml2:AttributeValue>
     </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/placeOfBirth_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/placeOfBirth_template.xml
@@ -1,6 +1,6 @@
 <saml2:Attribute 
 FriendlyName="PlaceOfBirth" 
-Name=" http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth"
-NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+Name="http://eidas.europa.eu/attributes/naturalperson/PlaceOfBirth"
+NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
 <saml2:AttributeValue xsi:type="eidas:PlaceOfBirthType">$value</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/resp_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/resp_template.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<saml2p:Response Destination="$Destination"
+<saml2p:Response Consent="urn:oasis:names:tc:SAML:2.0:consent:obtained" Destination="$Destination"
   ID="$Id" InResponseTo="$InResponseTo"
   IssueInstant="$IssueInstant" Version="2.0"
   xmlns:saml2p="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:xs="http://www.w3.org/2001/XMLSchema">

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/seed_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/seed_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="SEED"
-                Name=" http://eidas.europa.eu/attributes/legalperson/SEED"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/SEED"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:SEEDType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/sic_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/sic_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="SIC"
-                Name=" http://eidas.europa.eu/attributes/legalperson/SIC"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                Name="http://eidas.europa.eu/attributes/legalperson/SIC"
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:SICType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/taxreference_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/taxreference_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="TaxReference"
                 Name="http://eidas.europa.eu/attributes/legalperson/TaxReference"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:TaxReferenceType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/vatregistration_template.xml
+++ b/eidas-starterkit/src/main/resources/de/governikus/eumw/eidasstarterkit/template/vatregistration_template.xml
@@ -1,5 +1,5 @@
 <saml2:Attribute FriendlyName="VATRegistration"
                 Name="http://eidas.europa.eu/attributes/legalperson/VATRegistrationNumber"
-                NameFormat="urn:oasis:names:tc:SAML:2.0:attrnameformat:uri">
+                NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:uri">
     <saml2:AttributeValue xsi:type="eidas:VATRegistrationNumberType">$latinScript</saml2:AttributeValue>
 </saml2:Attribute>

--- a/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/TestEidasSaml.java
+++ b/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/TestEidasSaml.java
@@ -11,6 +11,7 @@
 package de.governikus.eumw.eidasstarterkit;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -295,7 +296,7 @@ public class TestEidasSaml
     EidasResponse result = EidasResponse.parse(new ByteArrayInputStream(response), keypair, cert);
 
     assertEquals(result.getDestination(), destination);
-    assertEquals(result.getNameId().getValue(), nameid.getValue());
+    assertNull(result.getNameId());
     assertEquals(result.getIssuer(), issuer);
     assertEquals(result.getInResponseTo(), inResponseTo);
 


### PR DESCRIPTION
This PR includes a series of updates that we transferred from our 1.0.6 updates.

Except from an update to the Eidas signer that I know is not wanted, the rest are reasonable fixes and updates:

- Allowing empty or absent RelayState in requests
- Removing Carriage Return (13) html entities from responses (creating problems for some signature validators)
- Fixing several SAML issues:
     - Illegal NameFormat URI:s
     - Leading paces in XML attributes
     - Declaration of consent in responses
     - Missing NameQualifier in Subject
     - Wrong order of elements in CurentAddress
     - Removing Assertions with false identity statements from error responses.
