### PR TITLE
Update TerminalAuthentication.java

### DIFF
--- a/poseidas/src/main/java/de/governikus/eumw/poseidas/cardserver/eac/ta/TerminalAuthentication.java
+++ b/poseidas/src/main/java/de/governikus/eumw/poseidas/cardserver/eac/ta/TerminalAuthentication.java
@@ -25,6 +25,7 @@ import de.governikus.eumw.poseidas.cardbase.ByteUtil;
 import de.governikus.eumw.poseidas.cardbase.asn1.OID;
 import de.governikus.eumw.poseidas.cardserver.service.ServiceRegistry;
 import de.governikus.eumw.poseidas.cardserver.service.hsm.HSMServiceFactory;
+import de.governikus.eumw.poseidas.cardserver.service.hsm.impl.BOSHSMSimulatorService;
 import de.governikus.eumw.poseidas.cardserver.service.hsm.impl.HSMException;
 import de.governikus.eumw.poseidas.cardserver.service.hsm.impl.HSMService;
 
@@ -74,9 +75,19 @@ public class TerminalAuthentication
     AssertUtil.notNullOrEmpty(compOwnEphPubKey, "compressed own public key");
 
     byte[] completeChallenge = ByteUtil.combine(new byte[][]{idPicc, rPicc, compOwnEphPubKey, auxiliaryData});
+/*
+    This is the original code:
+    Running this of PKCS11 hsm does not work as it attempts to use the CHR value as key alias.
+    This alias does not exist in our HSM.
+
     HSMService hsm = ServiceRegistry.Util.getServiceRegistry()
                                          .getService(HSMServiceFactory.class)
                                          .getHSMService();
+*/
+    //Forcing to not use HSM
+    HSMService hsm = ServiceRegistry.Util.getServiceRegistry()
+      .getService(HSMServiceFactory.class)
+      .getHSMService(BOSHSMSimulatorService.class);
 
     return hsm.sign(alias, algorithm, completeChallenge);
   }


### PR DESCRIPTION
In our attempts to deploy middleware version 1.1.0 with HSM we encountered the issue that middleware attempted to find the terminal authentication key (which we assume is fairly short lived) using the current CHR identifier as alias. 

We could not find any instructions that such key should be stored in the HSM or how to maintain such key in the HSM.

We solved the issue using this fix which forces the terminal authentication to use the BOSHSMSimulatorService instead of the PKCS11 service. After this patch everything worked perfectly.

We are open for the fact that we may have made some mistake or overlooked some steps. This PR is therefore more a question about this issue than a proposed fix.