### PR TITLE
Bugfix - Faulty check for both ProviderName and RequesterID

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ packer/
 .idea/
 
 */_build
+
+.DS_Store

--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasRequest.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasRequest.java
@@ -393,7 +393,8 @@ public class EidasRequest
 
   private static void setRequesterIdOrProviderName(EidasRequest eidasReq) throws ErrorCodeException
   {
-    checkIfRequesterIdAndProviderNameArePresent(eidasReq);
+    // This check is in error. There is no conflict if requesterID and Provider name are present
+    //checkIfRequesterIdAndProviderNameArePresent(eidasReq);
 
     if (isRequesterIdPresent(eidasReq))
     {
@@ -411,6 +412,7 @@ public class EidasRequest
     }
   }
 
+/*
   private static void checkIfRequesterIdAndProviderNameArePresent(EidasRequest eidasReq)
     throws ErrorCodeException
   {
@@ -421,6 +423,7 @@ public class EidasRequest
                                    "Both requesterId and providerName attributes are present");
     }
   }
+*/
 
   private static EidasLoA getAuthnContextClassRefFromAuthnRequest(EidasRequest eidasReq)
     throws ErrorCodeException

--- a/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/EidasRequestTest.java
+++ b/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/EidasRequestTest.java
@@ -57,6 +57,7 @@ class EidasRequestTest
                             errorCodeException.getMessage());
   }
 
+/*
   @Test
   void throwsExceptionWhenProviderNameAndRequesterIdPresent() throws Exception
   {
@@ -72,6 +73,7 @@ class EidasRequestTest
     Assertions.assertEquals("It was not possible to parse the SAML request: Both requesterId and providerName attributes are present.",
                             errorCodeException.getMessage());
   }
+*/
 
   @Test
   void parseSamlRequestWithOnlyProviderName() throws Exception


### PR DESCRIPTION
Version 2.0.0 has added a check if both ProviderName and RequesterID are present in the same request. If this is the case, then an error is thrown and the request is refused.

This interpretation has no support from neither SAML nor the eIDAS technical specifications. In fact. Having both these values present in a request is perfectly legal and provides no conflict.

The ProviderName is a "human-readable name of the requester" (as per SAML 2.0). The RequesterID provides zero or more identifiers with the following meaning: "Identifies the set of requesting entities on whose behalf the requester is acting"

IN other words. If the request is sent from the SE connector, then "Sweden eIDAS Connector" is a valid and typical ProviderName. But if that request was originated from service provider A with ID = "https://example.com/provider/a", then a RequesterID would be set to that value.

These attributes have completely different usage and semantics, and in fact, the SE connector sends both of them.

This bug-fix removes the faulty and redundant check both in code and in tests.