### PR TITLE
Bugfix SubjectConfirmation

### DIFF
--- a/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
+++ b/eidas-starterkit/src/main/java/de/governikus/eumw/eidasstarterkit/EidasResponse.java
@@ -678,6 +678,7 @@ public class EidasResponse
     subject.setNameID(nameID);
 
     SubjectConfirmation subjectConfirmation = new SubjectConfirmationBuilder().buildObject();
+    subjectConfirmation.setMethod("urn:oasis:names:tc:SAML:2.0:cm:bearer");
     SubjectConfirmationData subjectConfirmationData = new SubjectConfirmationDataBuilder().buildObject();
     subjectConfirmationData.setInResponseTo(inResponseTo);
     subjectConfirmationData.setNotBefore(now);


### PR DESCRIPTION
2.1.0 contains a SAML bug where the SubjectConfirmation element in the Subject element of the Assertion lacks the mandatory attribute "Method"

Current shape:
```
    <saml2:Subject>
        <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">DE/SE/B56AFFA83B5572537C406D285B78DC65B5E05513E3E9BEF9CD45154C43A361E2</saml2:NameID>
        <saml2:SubjectConfirmation>
            <saml2:SubjectConfirmationData
                InResponseTo="_1a374aab6da323931b7bba322d35dc55"
                NotBefore="2021-01-14T17:21:50.838Z"
                NotOnOrAfter="2021-01-14T17:31:50.838Z" Recipient="https://con.sandbox.swedenconnect.se/idp/extauth/saml2/post"/>
        </saml2:SubjectConfirmation>
    </saml2:Subject>

```
This should be:

```
    <saml2:Subject>
        <saml2:NameID Format="urn:oasis:names:tc:SAML:2.0:nameid-format:transient">DE/SE/B56AFFA83B5572537C406D285B78DC65B5E05513E3E9BEF9CD45154C43A361E2</saml2:NameID>
        <saml2:SubjectConfirmation Method="urn:oasis:names:tc:SAML:2.0:cm:bearer">
            <saml2:SubjectConfirmationData
                InResponseTo="_1a374aab6da323931b7bba322d35dc55"
                NotBefore="2021-01-14T17:21:50.838Z"
                NotOnOrAfter="2021-01-14T17:31:50.838Z" Recipient="https://con.sandbox.swedenconnect.se/idp/extauth/saml2/post"/>
        </saml2:SubjectConfirmation>
    </saml2:Subject>
```

This PR contains an easy fix to the problem