### PR TITLE
build: enforce JDK 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -366,6 +366,10 @@
                                     <version>[3.3,)</version>
                                 </requireMavenVersion>
 
+                                <requireJavaVersion>
+                                    <version>[1.8,9)</version>
+                                </requireJavaVersion>
+
                                 <dependencyConvergence />
 
                                 <requirePluginVersions>


### PR DESCRIPTION
Currently does not build on JDK > 8 due to removed `javax.xml.bind` package.

See: https://openjdk.org/jeps/320#Java-EE-modules

There is no `community` branch according to your https://github.com/Governikus/eidas-middleware/blob/master/CONTRIBUTING.md. So I'm using `master` as the base branch.

---

Contribution under EUPL-1.2.