### PR TITLE
docs: build from root dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ The signed release artifacts will be released on github as well.
 We are using maven to build and test the software.
 
 To build the software, execute the following command:
-```
-maven clean install
+
+```console
+$ maven clean install
 ```
 You can find the compiled JARs in the `target/` directory of each module.
 
@@ -24,11 +25,11 @@ on how to install sphinx on your system.
 
 To create the pdf file, issue the following commands:
 
-```
-cd doc && make clean latexpdf
+```console
+$ (cd doc && make clean latexpdf)
 ```
 
-The created pdf document can be found at `_build/latex/eIDASMiddleware.pdf`.
+The created pdf document can be found at `doc/_build/latex/eIDASMiddleware.pdf`.
 
 ## Documentation
 The user documentation for each release is available in the release artifacts.


### PR DESCRIPTION
This way you don't have to switch back directories after building the docs.

There is no `community` branch according to your https://github.com/Governikus/eidas-middleware/blob/master/CONTRIBUTING.md. So I'm using `master` as the base branch.

---

Contribution under EUPL-1.2.