### PR TITLE
Optimize SHA pattern matching in CryptoAlgUtil

### DIFF
--- a/eidas-common/src/main/java/de/governikus/eumw/eidascommon/CryptoAlgUtil.java
+++ b/eidas-common/src/main/java/de/governikus/eumw/eidascommon/CryptoAlgUtil.java
@@ -5,6 +5,8 @@ import org.opensaml.xmlsec.signature.support.SignatureConstants;
 
 import lombok.experimental.UtilityClass;
 
+import java.util.regex.Pattern;
+
 
 /**
  * Utility class for cryptographic algorithm lookup.
@@ -17,11 +19,11 @@ public class CryptoAlgUtil
 
   private final String RSA = "RSA";
 
-  private final String SHA_256_PATTERN = "^SHA-?256";
+  private final Pattern SHA_256_PATTERN = Pattern.compile("^SHA-?256");
 
-  private final String SHA_384_PATTERN = "^SHA-?384";
+  private final Pattern SHA_384_PATTERN =  Pattern.compile("^SHA-?384");
 
-  private final String SHA_512_PATTERN = "^SHA-?512";
+  private final Pattern SHA_512_PATTERN = Pattern.compile("^SHA-?512");
 
   private final String UNSUPPORTED_DIGEST_ALGORITHM = "Unsupported digest algorithm ";
 
@@ -35,15 +37,15 @@ public class CryptoAlgUtil
    */
   public String toXmlDigestAlgId(String digestAlg)
   {
-    if (digestAlg.matches(SHA_256_PATTERN))
+    if (SHA_256_PATTERN.matcher(digestAlg).matches())
     {
       return SignatureConstants.ALGO_ID_DIGEST_SHA256;
     }
-    else if (digestAlg.matches(SHA_384_PATTERN))
+    else if (SHA_384_PATTERN.matcher(digestAlg).matches())
     {
       return SignatureConstants.ALGO_ID_DIGEST_SHA384;
     }
-    else if (digestAlg.matches(SHA_512_PATTERN))
+    else if (SHA_512_PATTERN.matcher(digestAlg).matches())
     {
       return SignatureConstants.ALGO_ID_DIGEST_SHA512;
     }
@@ -66,30 +68,30 @@ public class CryptoAlgUtil
     switch (keyAlg)
     {
       case RSA:
-        if (digestAlg.matches(SHA_256_PATTERN))
+        if (SHA_256_PATTERN.matcher(digestAlg).matches())
         {
           return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA256_MGF1;
         }
-        if (digestAlg.matches(SHA_384_PATTERN))
+        if (SHA_384_PATTERN.matcher(digestAlg).matches())
         {
           return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA384_MGF1;
         }
-        if (digestAlg.matches(SHA_512_PATTERN))
+        if (SHA_512_PATTERN.matcher(digestAlg).matches())
         {
           return XMLSignature.ALGO_ID_SIGNATURE_RSA_SHA512_MGF1;
         }
         throw new IllegalArgumentException(UNSUPPORTED_DIGEST_ALGORITHM + digestAlg
                                            + USE_SHA256_SHA384_OR_SHA512);
       case EC:
-        if (digestAlg.matches(SHA_256_PATTERN))
+        if (SHA_256_PATTERN.matcher(digestAlg).matches())
         {
           return XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA256;
         }
-        if (digestAlg.matches(SHA_384_PATTERN))
+        if (SHA_384_PATTERN.matcher(digestAlg).matches())
         {
           return XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA384;
         }
-        if (digestAlg.matches(SHA_512_PATTERN))
+        if (SHA_512_PATTERN.matcher(digestAlg).matches())
         {
           return XMLSignature.ALGO_ID_SIGNATURE_ECDSA_SHA512;
         }
@@ -112,30 +114,30 @@ public class CryptoAlgUtil
     switch (keyAlg)
     {
       case RSA:
-        if (digestAlg.matches(SHA_256_PATTERN))
+        if (SHA_256_PATTERN.matcher(digestAlg).matches())
         {
           return "SHA256withRSAandMGF1";
         }
-        if (digestAlg.matches(SHA_384_PATTERN))
+        if (SHA_384_PATTERN.matcher(digestAlg).matches())
         {
           return "SHA384withRSAandMGF1";
         }
-        if (digestAlg.matches(SHA_512_PATTERN))
+        if (SHA_512_PATTERN.matcher(digestAlg).matches())
         {
           return "SHA512withRSAandMGF1";
         }
         throw new IllegalArgumentException(UNSUPPORTED_DIGEST_ALGORITHM + digestAlg
                                            + USE_SHA256_SHA384_OR_SHA512);
       case EC:
-        if (digestAlg.matches(SHA_256_PATTERN))
+        if (SHA_256_PATTERN.matcher(digestAlg).matches())
         {
           return "SHA256withECDSA";
         }
-        if (digestAlg.matches(SHA_384_PATTERN))
+        if (SHA_384_PATTERN.matcher(digestAlg).matches())
         {
           return "SHA384withECDSA";
         }
-        if (digestAlg.matches(SHA_512_PATTERN))
+        if (SHA_512_PATTERN.matcher(digestAlg).matches())
         {
           return "SHA512withECDSA";
         }


### PR DESCRIPTION
Patterns for SHA-256, SHA-384 and SHA-512 previously setup using strings have been changed to use java.util.regex.Pattern instead. This is followed by altering matches() method to matcher().matches() for these patterns. This modification aims to optimize the pattern matching process by precompiling the regex patterns, resulting in improved performance especially when same regex pattern is used multiple times in the code.