### PR TITLE
Refactor character encoding method usage

### DIFF
--- a/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/controller/RequestReceiver.java
+++ b/eidas-middleware/src/main/java/de/governikus/eumw/eidasmiddleware/controller/RequestReceiver.java
@@ -176,33 +176,26 @@ public class RequestReceiver
    */
   private ModelAndView showMiddlewarePage(String sessionId, String userAgent)
   {
-    try
+    String ausweisappLink;
+    if (isMobileDevice(userAgent))
     {
-      String ausweisappLink;
-      if (isMobileDevice(userAgent))
-      {
-        ausweisappLink = "eid://127.0.0.1:24727/eID-Client?tcTokenURL=";
-      }
-      else
-      {
-        ausweisappLink = "http://127.0.0.1:24727/eID-Client?tcTokenURL=";
-      }
-      ModelAndView modelAndView = new ModelAndView("middleware");
-
-      String tcTokenURL = requestHandler.getTcTokenURL(sessionId);
-      modelAndView.addObject("tcTokenURL", tcTokenURL);
-
-      ausweisappLink = ausweisappLink.concat(URLEncoder.encode(tcTokenURL, StandardCharsets.UTF_8.name()));
-      modelAndView.addObject("ausweisapp", ausweisappLink);
-
-      String linkToSelf = ContextPaths.EIDAS_CONTEXT_PATH + ContextPaths.REQUEST_RECEIVER + "?sessionId=" + sessionId;
-      modelAndView.addObject("linkToSelf", linkToSelf);
-      return modelAndView;
+      ausweisappLink = "eid://127.0.0.1:24727/eID-Client?tcTokenURL=";
     }
-    catch (UnsupportedEncodingException e)
+    else
     {
-      return showErrorPage(e.getMessage());
+      ausweisappLink = "http://127.0.0.1:24727/eID-Client?tcTokenURL=";
     }
+    ModelAndView modelAndView = new ModelAndView("middleware");
+
+    String tcTokenURL = requestHandler.getTcTokenURL(sessionId);
+    modelAndView.addObject("tcTokenURL", tcTokenURL);
+
+    ausweisappLink = ausweisappLink.concat(URLEncoder.encode(tcTokenURL, StandardCharsets.UTF_8));
+    modelAndView.addObject("ausweisapp", ausweisappLink);
+
+    String linkToSelf = ContextPaths.EIDAS_CONTEXT_PATH + ContextPaths.REQUEST_RECEIVER + "?sessionId=" + sessionId;
+    modelAndView.addObject("linkToSelf", linkToSelf);
+    return modelAndView;
   }
 
   private ModelAndView showSamlErrorPage(ErrorCodeWithResponseException e, String relayState)

--- a/eidas-middleware/src/test/java/de/governikus/eumw/eidasmiddleware/controller/RequestReceiverTest.java
+++ b/eidas-middleware/src/test/java/de/governikus/eumw/eidasmiddleware/controller/RequestReceiverTest.java
@@ -69,7 +69,7 @@ class RequestReceiverTest
     ModelMap modelMap = landingPage.getModelMap();
     Assertions.assertEquals(3, modelMap.size());
     Assertions.assertEquals(EID_CLIENT_URL
-                            + URLEncoder.encode(TC_TOKEN_URL + REQUEST_ID, StandardCharsets.UTF_8.name()),
+                            + URLEncoder.encode(TC_TOKEN_URL + REQUEST_ID, StandardCharsets.UTF_8),
                             modelMap.getAttribute("ausweisapp"));
     Assertions.assertEquals(ContextPaths.EIDAS_CONTEXT_PATH + ContextPaths.REQUEST_RECEIVER + "?sessionId="
                             + REQUEST_ID,
@@ -88,7 +88,7 @@ class RequestReceiverTest
     ModelMap modelMap = landingPage.getModelMap();
     Assertions.assertEquals(3, modelMap.size());
     Assertions.assertEquals(EID_CLIENT_URL
-                            + URLEncoder.encode(TC_TOKEN_URL + REQUEST_ID, StandardCharsets.UTF_8.name()),
+                            + URLEncoder.encode(TC_TOKEN_URL + REQUEST_ID, StandardCharsets.UTF_8),
                             modelMap.getAttribute("ausweisapp"));
     Assertions.assertEquals(ContextPaths.EIDAS_CONTEXT_PATH + ContextPaths.REQUEST_RECEIVER + "?sessionId="
                             + REQUEST_ID,
@@ -197,7 +197,7 @@ class RequestReceiverTest
     ModelMap modelMap = landingPage.getModelMap();
     Assertions.assertEquals(3, modelMap.size());
     Assertions.assertEquals(EID_CLIENT_MOBIL_URL
-                            + URLEncoder.encode(TC_TOKEN_URL + REQUEST_ID, StandardCharsets.UTF_8.name()),
+                            + URLEncoder.encode(TC_TOKEN_URL + REQUEST_ID, StandardCharsets.UTF_8),
                             modelMap.getAttribute("ausweisapp"));
     Assertions.assertEquals(ContextPaths.EIDAS_CONTEXT_PATH + ContextPaths.REQUEST_RECEIVER + "?sessionId="
                             + REQUEST_ID,

--- a/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/person_attributes/natural_persons_attribute/DateOfBirthAttributeTest.java
+++ b/eidas-starterkit/src/test/java/de/governikus/eumw/eidasstarterkit/person_attributes/natural_persons_attribute/DateOfBirthAttributeTest.java
@@ -53,7 +53,7 @@ class DateOfBirthAttributeTest
     ByteArrayOutputStream bout = new ByteArrayOutputStream();
     trans.transform(new DOMSource(all), new StreamResult(bout));
 
-    String attrString = new String(bout.toByteArray(), StandardCharsets.UTF_8.name());
+    String attrString = bout.toString(StandardCharsets.UTF_8);
     assertTrue(attrString.contains(testDate));
   }
 }


### PR DESCRIPTION
This commit simplifies the usage of character encoding methods. StandardCharsets.UTF_8.name() was replaced by StandardCharsets.UTF_8 in several places. This was done to improve code readability since StandardCharsets.UTF_8.name() and StandardCharsets.UTF_8 essentially do the same thing. Additionally, try-catch block related to encoding in RequestReceiver class has been removed since the encoding method used will not throw an exception, therefore the block was redundant.