### PR TITLE
Add missing repo for net.shibboleth.utilities.java-support 8.4.0

### DIFF
--- a/eidas-common/pom.xml
+++ b/eidas-common/pom.xml
@@ -21,6 +21,18 @@
     <name>${project.artifactId}</name>
     <description>Common sources for all eIDAS modules</description>
 
+    <repositories>
+        <repository>
+            <id>shib-release</id>
+            <url>
+                https://build.shibboleth.net/nexus/content/groups/public
+            </url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+    </repositories>
+
     <dependencies>
         <dependency>
             <groupId>de.governikus.eumw</groupId>


### PR DESCRIPTION
Version 3.1.0 declares (through version.javasupport prop) a dependency to version 8.4.0, which only exists in the shibboleth-releases repository, and thus it must be added:
https://mvnrepository.com/artifact/net.shibboleth.utilities/java-support?repo=shibboleth-releases

Without this addition, maven fails with the following error logged:

> [ERROR] Failed to execute goal on project eidas-common: Could not resolve dependencies for project de.governikus.eumw:eidas-common:jar:3.1.0: Could not find artifact net.shibboleth.utilities:java-support:jar:8.4.0 in central (https://repo.maven.apache.org/maven2) -> [Help 1]
> org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal on project eidas-common: Could not resolve dependencies for project de.governikus.eumw:eidas-common:jar:3.1.0: Could not find artifact net.shibboleth.utilities:java-support:jar:8.4.0 in central (https://repo.maven.apache.org/maven2)
