### PR TITLE
Remove checkCipherData

### DIFF
--- a/poseidas/src/main/java/de/governikus/eumw/poseidas/cardbase/crypto/CipherUtil.java
+++ b/poseidas/src/main/java/de/governikus/eumw/poseidas/cardbase/crypto/CipherUtil.java
@@ -253,26 +253,6 @@ public final class CipherUtil
   }
 
   /**
-   * Perform simple checks for data to be ciphered: data not <code>null</code> or empty array and length of
-   * data is multiple of key size.
-   *
-   * @param data data to be ciphered and checked, <code>null</code> or empty array not permitted, length of
-   *          data must be multiple of key size
-   * @param algorithm algorithm of key
-   * @param keyLength size of key
-   * @throws IllegalArgumentException if check of data fails
-   */
-  private static void checkCipherData(byte[] data, String algorithm, int keyLength)
-  {
-    AssertUtil.notNullOrEmpty(data, "data");
-    if (data.length % keyLength != 0)
-    {
-      throw new IllegalArgumentException("only padded data to multiple of " + algorithm + " key size "
-                                         + keyLength + " permitted, length of data: " + data.length);
-    }
-  }
-
-  /**
    * Constant of separator String for algorithm, block mode and padding at transformation: <tt>/</tt>.
    *
    * @see #getTransformationParts(String)
@@ -436,7 +416,6 @@ public final class CipherUtil
   {
     checkCipherKey(key, ALGORITHM_AES, KEY_SIZES_LIST_AES);
     checkCipherMode(mode);
-    checkCipherData(data, ALGORITHM_AES, key.getEncoded().length);
     Cipher cipher = getCipher(algorithm, key, mode, iv, provider);
     return cipher.doFinal(data);
   }


### PR DESCRIPTION
Remove checkCipherData, as it causes problems with CA_ECDH_AES_CBC_CMAC_192 and CA_ECDH_AES_CBC_CMAC_256. Block size is not always a multiple of key size (ex AES). E.g. using CA_ECDH_AES_CBC_CMAC_192 the encoded key has a length of 192 bits (24 bytes), of which the AES block size (128 bits / 16 bytes) is not a multiple. An incorrect block size is also detected by the underlying classes. Removing this function call made it possible to run conformance tests with CA_ECDH_AES_CBC_CMAC_192 and CA_ECDH_AES_CBC_CMAC_256.

I attached a debugging screenshot of the updateEncryptedIV function showing the exception from the mentioned function.
Version 2.2.7 was used for confirming the bug.

![Bildschirmfoto 2024-05-28 um 19 06 02](https://github.com/Governikus/eidas-middleware/assets/3269242/da5f151e-36c8-4202-8e87-ee1115760547)
